### PR TITLE
DEV: Improve pubsub startup reliability

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -27,7 +27,7 @@ if [ $? -eq 0 ]; then
     (
         env PUBSUB_EMULATOR_HOST=localhost:8681 npm run start
 		# Used for docker compose healthcheck
-        echo -e "HTTP/1.1 200 OK\n\n OK" | nc -l 8682
+		while true; do { echo -ne "HTTP/1.1 200 OK\r\n"; echo -ne "Content-Length: 0\r\n"; echo -ne "\r\n"; } | nc -l -p 8682 -q 1 & wait $!; done
     ) &
 fi
 


### PR DESCRIPTION
* Increase timeout for starting the pubsub emulator (usually the wait-for runs into timeout before the server starts)
* Exit the whole script when timeout reached, to exit the container
* Start simple webserver for docker compose healthchecks - ensure that pubsub is started before running integration tests